### PR TITLE
Cache rendered matches in memory and serve via web API

### DIFF
--- a/src/main/kotlin/dev/rayzr/gameboi/Gameboi.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/Gameboi.kt
@@ -9,6 +9,10 @@ import dev.rayzr.gameboi.game.Player
 import dev.rayzr.gameboi.listener.MessageListener
 import dev.rayzr.gameboi.listener.ReactionListener
 import dev.rayzr.gameboi.manager.MatchManager
+import dev.rayzr.gameboi.manager.RenderManager
+import io.javalin.Javalin
+import io.javalin.apibuilder.ApiBuilder.get
+import io.javalin.apibuilder.ApiBuilder.path
 import net.dv8tion.jda.api.OnlineStatus
 import net.dv8tion.jda.api.Permission
 import net.dv8tion.jda.api.entities.Activity
@@ -59,6 +63,15 @@ fun main() {
     if (Gameboi.updateStatus) {
         Timer().scheduleAtFixedRate(0L, 30000L) { Gameboi.updatePresence() }
     }
+
+    Javalin.create().routes {
+        path("matches") {
+            path(":match-id") {
+                // TODO: get state via API route
+                get("render/:state-id", RenderManager::handleRenderReq)
+            }
+        }
+    }.start(Gameboi.port)
 }
 
 object Gameboi : EventListener {
@@ -70,6 +83,8 @@ object Gameboi : EventListener {
     var shardCount: Int = 1
     var updateStatus: Boolean = true
     var errorLife: Long = 0
+    lateinit var host: String
+    var port: Int = 1
 
 
     fun load() {
@@ -87,6 +102,8 @@ object Gameboi : EventListener {
         shardCount = (output["shards"] ?: 1) as Int
         updateStatus = output["update-status"] as Boolean? ?: true
         errorLife = output["error-life"]?.toString()?.toLong() ?: 15000
+        host = output["host"].toString()
+        port = (output["port"] ?: 7000) as Int
     }
 
     val commands: List<Command> = listOf(

--- a/src/main/kotlin/dev/rayzr/gameboi/Gameboi.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/Gameboi.kt
@@ -68,7 +68,7 @@ fun main() {
         path("matches") {
             path(":match-id") {
                 // TODO: get state via API route
-                get("render/:state-id", RenderManager::handleRenderReq)
+                get("render", RenderManager::handleRenderReq)
             }
         }
     }.start(Gameboi.port)
@@ -122,6 +122,7 @@ object Gameboi : EventListener {
         HangmanInvite,
         // Match commands
         QuitCommand,
+        BumpCommand,
         // Shop commands
         ShopCommand,
         BuyCommand,

--- a/src/main/kotlin/dev/rayzr/gameboi/command/MatchCommands.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/command/MatchCommands.kt
@@ -20,3 +20,21 @@ object QuitCommand : Command("quit", "Quits you from your current match", catego
         }
     }
 }
+
+object BumpCommand :
+    Command("bump", "Bumps your match timeout and brings it to the bottom of chat", category = Categories.MATCH) {
+    override fun handle(event: GuildMessageReceivedEvent, args: List<String>) {
+        val player = Player[event.author]
+        val match = player.currentMatch
+
+        if (match == null) {
+            event.channel.sendMessage(":x: You are not in a match currently!").queue {
+                it.textChannel.deleteMessages(listOf(it, event.message))
+                    .queueAfter(Gameboi.errorLife, TimeUnit.MILLISECONDS)
+            }
+            return
+        }
+
+        match.renderContext.bump()
+    }
+}

--- a/src/main/kotlin/dev/rayzr/gameboi/game/Game.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/game/Game.kt
@@ -16,13 +16,8 @@ abstract class Game(private val width: Int, private val height: Int, val name: S
     ) {
         match.renderContext.clear()
         function.invoke(match.renderContext)
-        match.renderContext.draw(embedDescription, messageContents) {
-            addReactions(it, reactions)
-        }
+        match.renderContext.draw(embedDescription, messageContents, reactions)
     }
-
-    private fun addReactions(message: Message, reactions: List<String>) =
-        reactions.forEach { message.addReaction(it).queue() }
 
     abstract fun begin(match: Match)
     abstract fun handleMessage(player: Player, match: Match, message: Message)

--- a/src/main/kotlin/dev/rayzr/gameboi/game/Match.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/game/Match.kt
@@ -2,6 +2,7 @@ package dev.rayzr.gameboi.game
 
 import dev.rayzr.gameboi.manager.MatchManager
 import net.dv8tion.jda.api.entities.TextChannel
+import java.util.*
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
@@ -9,6 +10,8 @@ val MATCH_TIMEOUT = TimeUnit.MINUTES.toMillis(15)
 
 class Match(val game: Game, val channel: TextChannel) {
     private var scheduledFuture: ScheduledFuture<*>? = null
+
+    val id = UUID.randomUUID()
 
     val players = mutableListOf<Player>()
     val renderContext = game.createRenderContext(this)

--- a/src/main/kotlin/dev/rayzr/gameboi/game/connect4/Connect4Game.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/game/connect4/Connect4Game.kt
@@ -104,8 +104,9 @@ object Connect4Game : Game(700, 600, "Connect 4", 2) {
         val data = getData(match)
         val board = data.board
 
+        reaction.removeReaction(player.user).queue()
+
         if (match.players.indexOf(player) != data.currentPlayer) {
-            reaction.removeReaction(player.user).queue()
             return
         }
 

--- a/src/main/kotlin/dev/rayzr/gameboi/game/fight/FightGame.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/game/fight/FightGame.kt
@@ -156,8 +156,9 @@ object FightGame : Game(800, 600, "Fight", 2) {
     override fun handleReaction(player: Player, match: Match, reaction: MessageReaction) {
         val data = getData(match)
 
+        reaction.removeReaction(player.user).queue()
+
         if (player != data.currentPlayer.player) {
-            reaction.removeReaction(player.user).queue()
             return
         }
 

--- a/src/main/kotlin/dev/rayzr/gameboi/game/twenty48/Twenty48Game.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/game/twenty48/Twenty48Game.kt
@@ -323,8 +323,9 @@ object Twenty48Game : Game(600, 600, "2048", 1) {
     override fun handleReaction(player: Player, match: Match, reaction: MessageReaction) {
         if (!emojis.contains(reaction.reactionEmote.name)) return
 
+        reaction.removeReaction(player.user).queue()
+
         if (!match.players.contains(player)) {
-            reaction.removeReaction(player.user).queue()
             return
         }
 
@@ -335,11 +336,7 @@ object Twenty48Game : Game(600, 600, "2048", 1) {
             else -> Direction.RIGHT
         }
 
-        if (!moveTiles(match, direction)) {
-            reaction.removeReaction(player.user).queue()
-            return
-        }
-
+        moveTiles(match, direction)
     }
 
     private fun getData(match: Match) = match.data as Twenty48MatchData

--- a/src/main/kotlin/dev/rayzr/gameboi/manager/RenderManager.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/manager/RenderManager.kt
@@ -1,0 +1,27 @@
+package dev.rayzr.gameboi.manager
+
+import io.javalin.http.Context
+import java.util.*
+
+object RenderManager {
+    fun handleRenderReq(context: Context) {
+        val matchId = UUID.fromString(context.pathParam("match-id"))
+        val stateId = UUID.fromString(context.pathParam("state-id"))
+
+        val render = getMatchRender(matchId, stateId)
+
+        if (render != null) {
+            context.contentType("image/png")
+                .status(200)
+                .result(render)
+        } else {
+            context.status(404)
+        }
+    }
+
+    fun getMatchRender(matchId: UUID, stateId: UUID): ByteArray? {
+        val match = MatchManager.currentMatches.find { it.id == matchId }
+
+        return match?.renderContext?.state?.get(stateId)
+    }
+}

--- a/src/main/kotlin/dev/rayzr/gameboi/manager/RenderManager.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/manager/RenderManager.kt
@@ -6,9 +6,8 @@ import java.util.*
 object RenderManager {
     fun handleRenderReq(context: Context) {
         val matchId = UUID.fromString(context.pathParam("match-id"))
-        val stateId = UUID.fromString(context.pathParam("state-id"))
 
-        val render = getMatchRender(matchId, stateId)
+        val render = getMatchRender(matchId)
 
         if (render != null) {
             context.contentType("image/png")
@@ -19,9 +18,9 @@ object RenderManager {
         }
     }
 
-    fun getMatchRender(matchId: UUID, stateId: UUID): ByteArray? {
+    fun getMatchRender(matchId: UUID): ByteArray? {
         val match = MatchManager.currentMatches.find { it.id == matchId }
 
-        return match?.renderContext?.state?.get(stateId)
+        return match?.renderContext?.lastRender
     }
 }

--- a/src/main/kotlin/dev/rayzr/gameboi/render/RenderContext.kt
+++ b/src/main/kotlin/dev/rayzr/gameboi/render/RenderContext.kt
@@ -4,23 +4,28 @@ import dev.rayzr.gameboi.Gameboi
 import dev.rayzr.gameboi.game.Match
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
 import java.awt.Color
 import java.awt.Graphics2D
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.util.*
 import javax.imageio.ImageIO
-import kotlin.collections.LinkedHashMap
+
+data class RenderOptions(
+    val embed: MessageEmbed,
+    val messageContents: String?,
+    val reactions: List<String>
+)
 
 class RenderContext(val match: Match, private val width: Int, height: Int) {
     val image: BufferedImage = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
     val graphics: Graphics2D
         get() = image.createGraphics()
 
-    val state = LinkedHashMap<UUID, ByteArray>()
-    var currentStateId: UUID? = null
-
+    var lastRenderOptions: RenderOptions? = null
     var lastMessage: Message? = null
+    var lastRender: ByteArray? = null
 
     fun clear() {
         graphics.clearRect(0, 0, image.width, image.height)
@@ -57,36 +62,44 @@ class RenderContext(val match: Match, private val width: Int, height: Int) {
         }
     }
 
-    fun draw(embedDescription: String? = null, messageContents: String? = null, callback: (Message) -> Unit = {}) {
-        val newStateId = UUID.randomUUID()
-        currentStateId = newStateId
-
-        state[newStateId] = toBytes()
-
-        // don't waste too much memory storing too many old copies
-        if (state.size > 5) {
-            state.remove(state.keys.first())
-        }
-
-        val builder = EmbedBuilder().setImage("${Gameboi.host}/matches/${match.id}/render/${newStateId}")
+    fun draw(embedDescription: String? = null, messageContents: String? = null, reactions: List<String> = emptyList()) {
+        // this does nothing other than just defeat caching
+        val state = UUID.randomUUID()
+        val imageUrl = "${Gameboi.host}/matches/${match.id}/render?state=${state}"
+        val embed = EmbedBuilder()
+            .setImage(imageUrl)
             .setFooter("${match.game.name} || Players: ${match.players.joinToString(", ") { it.user.name }}")
             .setColor(0x353940)
+            .apply { if (embedDescription != null) setDescription(embedDescription) }
+            .build()
 
-        if (embedDescription != null) {
-            builder.setDescription(embedDescription)
-        }
+        val renderOptions = RenderOptions(embed, messageContents, reactions)
+        lastRender = toBytes()
+        render(renderOptions)
+    }
 
-        val embed = builder.build()
+    fun render(renderOptions: RenderOptions) {
+        lastRenderOptions = renderOptions
+        val future = lastMessage?.editMessage(renderOptions.embed)?.content(renderOptions.messageContents)?.submit()
+            ?: match.channel.sendMessage(renderOptions.embed).content(renderOptions.messageContents).submit()
 
-        val future = lastMessage?.editMessage(embed)?.content(messageContents)?.submit()
-            ?: match.channel.sendMessage(embed).content(messageContents).submit()
-
-        future.thenAccept {
-            lastMessage = it
-            callback.invoke(it)
+        future.thenAccept { newMessage ->
+            lastMessage = newMessage
+            renderOptions.reactions.forEach { reaction ->
+                newMessage.addReaction(reaction).queue()
+            }
         }
 
         match.bumpTimeout()
+    }
+
+    fun bump() {
+        val renderOptions = lastRenderOptions
+            ?: throw IllegalStateException("You cannot call bump before having rendered at least once.")
+
+        lastMessage?.delete()?.queue()
+        lastMessage = null
+        render(renderOptions)
     }
 
     private fun toBytes(): ByteArray {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,3 +2,5 @@ prefix: "!"
 token: "12396510498gmj0194c8g1m0394gjm"
 shards: 1
 update-status: true
+host: "http://localhost:7000"
+port: 7000


### PR DESCRIPTION
as has been discussed for ages, it's generally a better UX to edit the game message rather than deleting and sending a new one each time. this implements that, by using Javalin to run a webserver that is capable of serving the rendered images. this also improves the UX by removing the need for:

1. re-adding emojis each time
2. waiting for the attachment to send to discord
3. deleting a message

therefore greatly improving the speed at which match renders can be updated. the image size still matters as it's a poor UX if the preview takes long to load, but the embed is able to be edited nearly instantaneously.

current UX hurdles that still require solutions before being released:
- [x] ~~game embeds can get buried in chat -- a command or emoji to "summon" the embed to the front of chat would be nice (delete old and send new, like the old way)~~
  - added new `!bump` command to address this
- [x] ~~`@mentions` of users don't actually notify when the message is edited rather than sent new -- this mainly impacts slower paced games like Connect 4 where you may have stepped away to do something while waiting for your opponent to make a move~~
  - decided this one isn't important, users can ping their play partner themselves (and this is better anyways as it's opt-in)
- [x] ~~emojis now persist, which is a double edged sword -- while we don't HAVE to re-add them each time now, it also means that if we want to change the available emojis between rounds, we have to come up with an algorithm for resolving what emojis need to be removed/added (especially to end up with the correct order)~~
  - we can tackle this when we actually have a game that would utilize it