### PR TITLE
Add basic Dockerfile

### DIFF
--- a/.deploy/Dockerfile
+++ b/.deploy/Dockerfile
@@ -1,0 +1,21 @@
+FROM maven:3-openjdk-11 AS builder
+
+WORKDIR /usr/src/build
+
+COPY pom.xml .
+COPY src src
+
+RUN mvn
+RUN cp target/gameboi-*-jar-with-dependencies.jar gameboi.jar
+
+FROM openjdk:11
+
+WORKDIR /usr/src/app
+
+COPY --from=builder /usr/src/build/gameboi.jar .
+COPY --from=builder /usr/src/build /usr/src/build
+COPY .deploy/start.sh .deploy/start.sh
+
+WORKDIR /var/gameboi
+
+CMD ["/usr/src/app/.deploy/start.sh"]

--- a/.deploy/build.sh
+++ b/.deploy/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd "$(dirname "$(realpath "$0")")/.." || exit 1
+
+docker build -t "${1:-rayzr522}/gameboi:latest" -f .deploy/Dockerfile .

--- a/.deploy/start.sh
+++ b/.deploy/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+java "${JAVA_ARGS[@]}" -jar /usr/src/app/gameboi.jar

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# non-code
+LICENSE
+README.md
+raw
+res
+
+# configs
+.deploy/Dockerfile
+.deploy/build.sh
+.dockerignore
+.gitignore
+
+# temp files
+.git
+target


### PR DESCRIPTION
build with `.deploy/build.sh` and run with:
```bash
docker run --rm -it -v $(pwd)/data:/var/gameboi rayzr522/gameboi
# or if you want it to run in the background and not be removed after it exits:
docker run -v $(pwd)/data:/var/gameboi rayzr522/gameboi
```
```
this assumes a `data` folder in your current directory, and gameboi will generate a config.yml for you

the only problem as it stands is that the bot runs as a root, meaning your data folder will be owned by root and so will your config.yml. one easy solution to this is to run the bot the first time to generate data/config.yml, and then run this to fix perms:
```bash
sudo chown -R $(whoami):$(whoami) data
```

it's not a great solution but it at least works